### PR TITLE
Added support for rtl_tcp

### DIFF
--- a/apps/dvbs2-rx
+++ b/apps/dvbs2-rx
@@ -95,6 +95,7 @@ class DVBS2RxTopBlock(gr.top_block, Qt.QWidget):
             'gain': options.rtl_gain,
             'idx': options.rtl_idx,
             'serial': options.rtl_serial,
+            'ipport': options.rtl_ipport,
         }
         self.sink = options.sink
         self.source = options.source
@@ -740,10 +741,11 @@ class DVBS2RxTopBlock(gr.top_block, Qt.QWidget):
 
         elif (self.source == "rtl"):
             import osmosdr  # lazy import to avoid failure if source != rtl
-            rtl_arg = self.rtl['serial'] if self.rtl['serial'] is not None \
-                else str(self.rtl['idx'])
-            self.rtlsdr_source = rtlsdr = osmosdr.source(
-                args="numchan=" + str(1) + " " + "rtl={}".format(rtl_arg))
+            if self.rtl['ipport'] is None:
+                rtl_arg = self.rtl['serial'] if self.rtl['serial'] is not None else str(self.rtl['idx'])
+                self.rtlsdr_source = rtlsdr = osmosdr.source(args="numchan=" + str(1) + " " + "rtl={}".format(rtl_arg))
+            else:
+                self.rtlsdr_source = rtlsdr = osmosdr.source(args="numchan=" + str(1) + " " + "rtl_tcp={}".format(self.rtl['ipport']))
             rtlsdr.set_time_unknown_pps(osmosdr.time_spec_t())
             rtlsdr.set_sample_rate(self.samp_rate)
             rtlsdr.set_center_freq(self.freq, 0)
@@ -1432,6 +1434,9 @@ def argument_parser():
     rtl_dev_group.add_argument("--rtl-serial",
                                type=str,
                                help="RTL-SDR serial number")
+    rtl_dev_group.add_argument("--rtl-ipport",
+                               type=str,
+                               help="rtl_tcp IP:port string")
 
     usrp_group = parser.add_argument_group('USRP Options')
     usrp_group.add_argument(


### PR DESCRIPTION
I added support for rtl_tcp osmosdr source blocks because I needed it for a virtualized receiver. Maybe it is of value for others, too.