### PR TITLE
plsync: add missing include

### DIFF
--- a/lib/plsync_cc_impl.cc
+++ b/lib/plsync_cc_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/expj.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
+#include <set>
 
 namespace gr {
 namespace dvbs2rx {


### PR DESCRIPTION
`#include <set>` was needed in this file to build in my Arch Linux system.