### PR TITLE
Fix Symbol Sync interpolation method not changing in GRC

### DIFF
--- a/grc/dvbs2rx_symbol_sync_cc.block.yml
+++ b/grc/dvbs2rx_symbol_sync_cc.block.yml
@@ -4,7 +4,7 @@ category: '[Core]/Digital Television/DVB-S2'
 
 templates:
   imports: from gnuradio import dvbs2rx
-  make: dvbs2rx.symbol_sync_cc(${sps}, ${loop_bw}, ${damping_factor}, ${rolloff}, ${rrc_delay}, ${n_subfilt}, ${interp_method})
+  make: dvbs2rx.symbol_sync_cc(${sps}, ${loop_bw}, ${damping_factor}, ${rolloff}, ${rrc_delay}, ${n_subfilt}, ${interp_method.val})
 
 parameters:
 - id: sps
@@ -27,18 +27,20 @@ parameters:
   label: RRC Filter Delay
   dtype: int
   default: 5
-  hide: ${'none' if interp_method == 0 else 'all'}
+  hide: ${interp_method.hide}
 - id: n_subfilt
   label: Polyphase Subfilters
   dtype: int
   default: 128
-  hide: ${'none' if interp_method == 0 else 'all'}
+  hide: ${interp_method.hide}
 - id: interp_method
   label: Interpolation Method
   dtype: enum
-  options: [0, 1, 2, 3]
+  options: [INTERP_POLYPHASE, INTERP_LINEAR, INTERP_QUADRATIC, INTERP_CUBIC]
   option_labels: ["Polyphase", "Linear", "Quadratic", "Cubic"]
-  default: 0
+  option_attributes:
+    val: [0, 1, 2, 3]
+    hide: [none, all, all, all]
 
 inputs:
 - label: in


### PR DESCRIPTION
Interpolation method (`enum`) of Symbol Sync block could not be changed in gnuradio-companion; probably because the `enum` type requires string options. Thus, `options` are changed from numbers to identifier strings. Numeric values are placed in the option attribute `val`, and hiding of other fields is controlled with option attribute `hide`.