### PR TITLE
Add DVB-S2 Multiple Input Stream support

### DIFF
--- a/apps/dvbs2-rx
+++ b/apps/dvbs2-rx
@@ -64,6 +64,7 @@ class DVBS2RxTopBlock(gr.top_block, Qt.QWidget):
         self.ldpc_iterations = options.ldpc_iterations
         self.modcod = options.modcod
         self.multistream = options.multistream
+        self.multistream_isi = options.multistream_isi
         self.out_fd = options.out_fd
         self.out_file = options.out_file
         self.out_stream = options.out_stream
@@ -866,7 +867,7 @@ class DVBS2RxTopBlock(gr.top_block, Qt.QWidget):
         bbdescrambler = dvbs2rx.bbdescrambler_bb(standard, frame_size,
                                                  code_rate)
         bbdeheader = dvbs2rx.bbdeheader_bb(standard, frame_size, code_rate,
-                                           self.debug)
+                                           self.multistream_isi, self.debug)
 
         self.connect((ldpc_decoder, 0), (bch_decoder, 0), (bbdescrambler, 0))
 
@@ -1234,6 +1235,12 @@ def argument_parser():
         help="Enable processing of multiple input streams (MIS mode). Set to "
         "\"auto\" if unsure about whether the input signal uses SIS or MIS. "
         "Otherwise, choose \"on\" or \"off\" for better performance.")
+    dvb_group.add_argument(
+        "--multistream-isi",
+        type=int,
+        default=0,
+        help="Select which stream to process when operating in MIS mode and "
+        "output stream is MPEG TS.")
     dvb_group.add_argument(
         '-p',
         "--pilots",

--- a/include/gnuradio/dvbs2rx/bbdeheader_bb.h
+++ b/include/gnuradio/dvbs2rx/bbdeheader_bb.h
@@ -40,6 +40,7 @@ public:
     static sptr make(dvb_standard_t standard,
                      dvb_framesize_t framesize,
                      dvb_code_rate_t rate,
+                     int multistream_isi = 0,
                      int debug_level = 0);
 
     /*!

--- a/lib/bbdeheader_bb_impl.cc
+++ b/lib/bbdeheader_bb_impl.cc
@@ -57,6 +57,7 @@ bbdeheader_bb_impl::bbdeheader_bb_impl(dvb_standard_t standard,
     get_fec_info(standard, framesize, rate, fec_info);
     d_kbch_bytes = fec_info.bch.k / 8;
     d_max_dfl = fec_info.bch.k - BB_HEADER_LENGTH_BITS;
+    d_up_length = TS_PACKET_LENGTH;
     set_output_multiple(d_max_dfl / 8); // ensure full BBFRAMEs on the input
 }
 
@@ -121,8 +122,22 @@ bool bbdeheader_bb_impl::parse_bbheader(u8_cptr_t in, BBHeader* h)
         return false;
     }
 
-    if (h->upl != (TS_PACKET_LENGTH * 8)) {
-        d_logger->warn("Baseband header unsupported (upl != 188 bytes).");
+    // UP length depends on NPD and ISSY features, moreover ISSY ISCR counter
+    // may be short (2 bytes) or long (3 bytes) format
+    if ((h->issyi == 1) || (h->npd == 1)) {
+        d_up_length = h->upl / 8;
+        if (h->npd == 1) {
+            d_logger->warn("Baseband header unsupported (npd not implemented).");
+            return false;
+        }
+        if ((h->issyi == 1) &&
+            (d_up_length != (TS_PACKET_LENGTH + 2)) &&
+            (d_up_length != (TS_PACKET_LENGTH + 3))) {
+            d_logger->warn("Baseband header unsupported (invalid issy upl).");
+            return false;
+        }
+    } else if (h->upl != (d_up_length * 8)) {
+        d_logger->warn("Baseband header unsupported (invalid upl).");
         return false;
     }
 
@@ -199,11 +214,11 @@ int bbdeheader_bb_impl::general_work(int noutput_items,
         }
 
         // Process the TS packets available on the DATAFIELD
-        while (df_remaining >= TS_PACKET_LENGTH) {
+        while (df_remaining >= d_up_length) {
             u8_cptr_t packet;
             // Start by completing a partial TS packet from the previous BBFRAME (if any)
             if (d_partial_ts_bytes > 0) {
-                unsigned int remaining = TS_PACKET_LENGTH - d_partial_ts_bytes;
+                unsigned int remaining = d_up_length - d_partial_ts_bytes;
                 memcpy(d_partial_pkt + d_partial_ts_bytes, in, remaining);
                 d_partial_ts_bytes = 0; // Reset the count
                 in += remaining;
@@ -211,11 +226,11 @@ int bbdeheader_bb_impl::general_work(int noutput_items,
                 packet = d_partial_pkt;
             } else {
                 packet = in;
-                in += TS_PACKET_LENGTH;
-                df_remaining -= TS_PACKET_LENGTH;
+                in += d_up_length;
+                df_remaining -= d_up_length;
             }
 
-            const bool crc_valid = check_crc8(packet, TS_PACKET_LENGTH);
+            const bool crc_valid = check_crc8(packet, d_up_length);
             out[0] = MPEG_TS_SYNC_BYTE; // Restore the sync byte
             memcpy(out + 1, packet, TS_PACKET_LENGTH - 1);
             if (!crc_valid) {

--- a/lib/bbdeheader_bb_impl.h
+++ b/lib/bbdeheader_bb_impl.h
@@ -44,6 +44,7 @@ private:
     unsigned int d_partial_ts_bytes; /**< Byte count of the partial TS packet
                                         extracted at the end of the previous BBFRAME */
     unsigned char d_partial_pkt[TS_PACKET_LENGTH+3]; /**< Partial TS packet storage */
+    const int d_multistream_isi;  /**< ISI to process in MIS mode */
     BBHeader d_bbheader;                           /**< Parsed BBHEADER */
     uint64_t d_packet_cnt;         /**< All-time count of received packets  */
     uint64_t d_error_cnt;          /**< All-time count of packets with bit errors */
@@ -76,6 +77,7 @@ public:
     bbdeheader_bb_impl(dvb_standard_t standard,
                        dvb_framesize_t framesize,
                        dvb_code_rate_t rate,
+                       int multistream_isi,
                        int debug_level);
     ~bbdeheader_bb_impl();
 

--- a/lib/bbdeheader_bb_impl.h
+++ b/lib/bbdeheader_bb_impl.h
@@ -39,10 +39,11 @@ private:
     const int d_debug_level;         /**< Debug level*/
     unsigned int d_kbch_bytes;       /**< BBFRAME length in bytes */
     unsigned int d_max_dfl;          /**< Maximum DATAFIELD length in bits */
+    unsigned int d_up_length;        /**< User-packet length in bytes */
     bool d_synched;                  /**< Synchronized to the start of TS packets */
     unsigned int d_partial_ts_bytes; /**< Byte count of the partial TS packet
                                         extracted at the end of the previous BBFRAME */
-    unsigned char d_partial_pkt[TS_PACKET_LENGTH]; /**< Partial TS packet storage */
+    unsigned char d_partial_pkt[TS_PACKET_LENGTH+3]; /**< Partial TS packet storage */
     BBHeader d_bbheader;                           /**< Parsed BBHEADER */
     uint64_t d_packet_cnt;         /**< All-time count of received packets  */
     uint64_t d_error_cnt;          /**< All-time count of packets with bit errors */

--- a/python/dvbs2rx/bindings/bbdeheader_bb_python.cc
+++ b/python/dvbs2rx/bindings/bbdeheader_bb_python.cc
@@ -40,6 +40,7 @@ void bind_bbdeheader_bb(py::module& m)
              py::arg("standard"),
              py::arg("framesize"),
              py::arg("rate"),
+             py::arg("multistream_isi") = 0,
              py::arg("debug_level") = 0,
              D(bbdeheader_bb, make))
 

--- a/python/dvbs2rx/bindings/bbdeheader_bb_python.cc
+++ b/python/dvbs2rx/bindings/bbdeheader_bb_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(bbdeheader_bb.h)                                           */
-/* BINDTOOL_HEADER_FILE_HASH(578413664762f19a0cacbaaec4388df9)                     */
+/* BINDTOOL_HEADER_FILE_HASH(2d9af3280cbe04ac25b1099852ed6091)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Add support for parsing BBFRAME when DVB-S2 ISSY feature is enabled. As a consequence Multiple Input Stream is now supported, add command line option to select which stream to process in TS mode.