### PR TITLE
fix: remove bogus sampling rate check

### DIFF
--- a/apps/dvbs2-rec
+++ b/apps/dvbs2-rec
@@ -115,7 +115,7 @@ class DVBS2RecTopBlock(gr.top_block, Qt.QWidget):
         self.gui_setup_complete = False
 
         # Adjust the sample rate to an integer if necessary
-        if self.source == 'plutosdr' and not self.samp_rate.is_integer():
+        if self.source == 'plutosdr':
             self.samp_rate = int(round(self.samp_rate))
             gr.log.warn("An integer sample rate is required by the PlutoSDR. "
                         "Setting rate to {:d} samples/sec.".format(

--- a/apps/dvbs2-rx
+++ b/apps/dvbs2-rx
@@ -143,7 +143,7 @@ class DVBS2RxTopBlock(gr.top_block, Qt.QWidget):
         self.gui_setup_complete = False
 
         # Adjust the sample rate to an integer if necessary
-        if self.source == 'plutosdr' and not self.samp_rate.is_integer():
+        if self.source == 'plutosdr':
             self.samp_rate = int(round(self.samp_rate))
             gr.log.warn("An integer sample rate is required by the PlutoSDR. "
                         "Setting rate to {:d} samples/sec.".format(

--- a/apps/dvbs2-tx
+++ b/apps/dvbs2-tx
@@ -162,7 +162,7 @@ class dvbs2_tx(gr.top_block, Qt.QWidget):
         self.uptime = datetime.now() - self.start_time
 
         # Adjust the sample rate to an integer if necessary
-        if self.sink == 'plutosdr' and not self.samp_rate.is_integer():
+        if self.sink == 'plutosdr':
             self.samp_rate = int(round(self.samp_rate))
             gr.log.warn("An integer sample rate is required by the PlutoSDR. "
                         "Setting rate to {:d} samples/sec.".format(


### PR DESCRIPTION
The plutosdr only accepts a value of datatype integer as sampling rate. For this, there already is a conversion logic, to convert float data type sampling rate values to integer data type. However, the conversion logic is flawed, as it only triggers for values of float data type **if the floating point number has decimals** (digits behind the dot). Therefore, values of floating point data type like `10` or `25000` are not converted to an integer data type, resulting in failure to initialize the plutosdr.

This patch removes the bogus check, always converting to integer type.

This is a fix to https://github.com/igorauad/gr-dvbs2rx/issues/38